### PR TITLE
ILAMB PBS+Model Route: deleted -e/-o in PBS and more comments for PBS and Model Route files

### DIFF
--- a/ilamb/pbs.job
+++ b/ilamb/pbs.job
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-#PBS -N workshop
+# For help with PBS directives on Gadi, go to https://opus.nci.org.au/display/Help/PBS+Directives+Explained
+#PBS -N ilamb_cmip6
 #PBS -l wd
 #PBS -P nf33
 #PBS -q express
@@ -9,19 +10,21 @@
 #PBS -l mem=63GB           
 #PBS -l jobfs=10GB        
 #PBS -l storage=gdata/nf33+gdata/fs38+gdata/oi10+gdata/xp65+gdata/hh5+gdata/ct11+scratch/nf33
-#PBS -o ./output_log
-#PBS -e ./error_log
 
+# ILAMB is provided through projects xp65 and hh5. We will use the latter here
 # module use /g/data/xp65/public/modules
 # module load conda/access-med
-
 module use /g/data/hh5/public/modules
 module load conda
 
+# Define the ILAMB Paths
 export ILAMB_ROOT_PARENT=/g/data/nf33/public/data/ILAMB
 export ILAMB_ROOT=$ILAMB_ROOT_PARENT/ILAMB_ROOT
 export CARTOPY_DATA_DIR=/g/data/xp65/public/apps/cartopy-data
 export BUILD_DIR=./ilamb_result/_build
 
+# Remove output of previous runs
 rm -rf $BUILD_DIR
-mpiexec -n 10 ilamb-run --config CMIP6.cfg --model_setup ./workshop_version.txt --regions global --build_dir $BUILD_DIR
+
+# Run ILAMB in parallel with the CMIP6i.cfg configure file for the models defined in workshop_version.txt
+mpiexec -n 10 ilamb-run --config CMIP6.cfg --model_setup workshop_version.txt --regions global --build_dir $BUILD_DIR

--- a/ilamb/workshop_version.txt
+++ b/ilamb/workshop_version.txt
@@ -1,3 +1,4 @@
-ACCESS_ESM1-5_r1i1p1f1 ,  CMIP/ACCESS-ESM1-5/historical/r1i1p1f1  ,CMIP6
-BCC-ESM1_r1i1p1f1,  CMIP/BCC-ESM1/historical/r1i1p1f1,    CMIP6
-CanESM5_r1i1p1f1,   CMIP/CanESM5/historical/r1i1p1f1,    CMIP6
+# Model Name (used as label), ABSOLUTE/PATH/TO/MODELS or relative to $ILAMB_ROOT/ , Optional comments
+ACCESS_ESM1-5_r1i1p1f1      , CMIP/ACCESS-ESM1-5/historical/r1i1p1f1              , CMIP6
+BCC-ESM1_r1i1p1f1           , CMIP/BCC-ESM1/historical/r1i1p1f1                   , CMIP6
+CanESM5_r1i1p1f1            , CMIP/CanESM5/historical/r1i1p1f1                    , CMIP6


### PR DESCRIPTION
- renamed jobs: #PBS -N ilamb_cmip6
- deleted #PBS -e and #PBS -o to have new error/output file for every job (in case the users try their run multiple scripts and one breaks)
- Added link to Gadi PBS directive help + a comments for each of the major steps in the PBS file
- Added head comment for the Model Route file